### PR TITLE
Support terminology

### DIFF
--- a/src/python/gambit/lib/game.pxi
+++ b/src/python/gambit/lib/game.pxi
@@ -22,7 +22,7 @@ cdef class Outcomes(Collection):
 cdef class Players(Collection):
     "Represents a collection of players in a game."
     cdef c_Game game
-    cdef StrategySupport support
+    cdef StrategicRestriction support
     def __len__(self):       return self.game.deref().NumPlayers()
     def __getitem__(self, pl):
         if not isinstance(pl, int):  return Collection.__getitem__(self, pl)
@@ -297,7 +297,7 @@ cdef class Game:
         return 0
 
     def restrict(self, SupportSet sp):
-        cdef StrategySupport new_support
+        cdef StrategicRestriction new_support
         support = self.support_set()
         if support >= sp:
             difference = set(support) - set(sp)

--- a/src/python/gambit/lib/game.pxi
+++ b/src/python/gambit/lib/game.pxi
@@ -296,18 +296,6 @@ cdef class Game:
             return self.game.deref().NumNodes()
         return 0
 
-    def restrict(self, StrategySupportProfile sp):
-        cdef StrategicRestriction new_support
-        support = self.support_set()
-        if support >= sp:
-            difference = set(support) - set(sp)
-            new_support = self.mixed_profile().support()
-            for strategy in difference:
-                new_support.support.RemoveStrategy((<Strategy>strategy).strategy)
-            return new_support
-        else:
-            raise UndefinedOperationError("cannot restrict game to a non-subset of it")
-
     def unrestrict(self):
         return self
 

--- a/src/python/gambit/lib/game.pxi
+++ b/src/python/gambit/lib/game.pxi
@@ -288,15 +288,15 @@ cdef class Game:
             raise UndefinedOperationError("Game must have a tree representation"\
                                       " to create a mixed behavior profile")
  
-    def support_set(self):
-        return SupportSet(list(self.strategies), len(self.players), self)
+    def support_profile(self):
+        return StrategySupportProfile(list(self.strategies), len(self.players), self)
 
     def num_nodes(self):
         if self.is_tree:
             return self.game.deref().NumNodes()
         return 0
 
-    def restrict(self, SupportSet sp):
+    def restrict(self, StrategySupportProfile sp):
         cdef StrategicRestriction new_support
         support = self.support_set()
         if support >= sp:

--- a/src/python/gambit/lib/libgambit.pyx
+++ b/src/python/gambit/lib/libgambit.pyx
@@ -275,8 +275,10 @@ cdef extern from "libgambit/stratspt.h":
         bool IsSubsetOf(c_StrategySupport)
         bool RemoveStrategy(c_GameStrategy)
         c_GameStrategy GetStrategy(int, int) except +IndexError
+        bool Contains(c_GameStrategy)
         c_StrategySupport Undominated(bool, bool)
     c_StrategySupport *new_StrategySupport "new StrategySupport"(c_Game)
+    c_StrategySupport *copy_StrategySupport "new StrategySupport"(c_StrategySupport)
     void del_StrategySupport "delete"(c_StrategySupport *)
 
 cdef extern from "util.h":

--- a/src/python/gambit/lib/mixed.pxi
+++ b/src/python/gambit/lib/mixed.pxi
@@ -150,8 +150,8 @@ cdef class MixedStrategyProfileDouble(MixedStrategyProfile):
         behav.profile = new_BehavFromMixedDouble(deref(self.profile))
         return behav
     def support(self):
-        cdef StrategySupport s
-        s = StrategySupport()
+        cdef StrategicRestriction s
+        s = StrategicRestriction()
         s.support = self.profile.GetSupport()#new_StrategySupport((<Game>self.game).game)#self.profile.GetSupport()
         return s
 
@@ -200,8 +200,8 @@ cdef class MixedStrategyProfileRational(MixedStrategyProfile):
         behav.profile = new_BehavFromMixedRational(deref(self.profile))
         return behav
     def support(self):
-        cdef StrategySupport s
-        s = StrategySupport()
+        cdef StrategicRestriction s
+        s = StrategicRestriction()
         s.support = self.profile.GetSupport()
         return s
     

--- a/src/python/gambit/lib/outcome.pxi
+++ b/src/python/gambit/lib/outcome.pxi
@@ -1,6 +1,6 @@
 cdef class Outcome:
     cdef c_GameOutcome outcome
-    cdef StrategySupport support
+    cdef StrategicRestriction support
     
     def __repr__(self):
         return "<Outcome [%d] '%s' in game '%s'>" % (self.outcome.deref().GetNumber()-1,

--- a/src/python/gambit/lib/player.pxi
+++ b/src/python/gambit/lib/player.pxi
@@ -38,13 +38,13 @@ cdef class Strategies(Collection):
 cdef class PlayerSupportStrategies(Collection):
     "Represents a collection of strategies for a player in a support"
     cdef Player player
-    cdef StrategySupport support
+    cdef StrategicRestriction support
 
     def add(self, label=""):
         raise UndefinedOperationError("Adding strategies is only applicable"\
                                       "to players in a game, not in a support")
 
-    def __init__(self, Player player not None, StrategySupport support not None):
+    def __init__(self, Player player not None, StrategicRestriction support not None):
         self.support = support
         self.player = player
     
@@ -61,7 +61,7 @@ cdef class PlayerSupportStrategies(Collection):
 
 cdef class Player:
     cdef c_GamePlayer player
-    cdef StrategySupport support
+    cdef StrategicRestriction support
 
     def __repr__(self):
         if self.is_chance:

--- a/src/python/gambit/lib/strategy.pxi
+++ b/src/python/gambit/lib/strategy.pxi
@@ -2,7 +2,7 @@ from gambit.lib.error import UndefinedOperationError
 
 cdef class Strategy:
     cdef c_GameStrategy strategy
-    cdef StrategySupport support
+    cdef StrategicRestriction support
 
     def __repr__(self):
         return "<Strategy [%d] '%s' for player '%s' in game '%s'>" % \

--- a/src/python/gambit/lib/stratspt.pxi
+++ b/src/python/gambit/lib/stratspt.pxi
@@ -153,7 +153,7 @@ cdef class StrategicRestriction(BaseGame):
     cdef c_StrategySupport support
 
     def __repr__(self):
-        return "<Support from Game '%s'>" % self.title
+        return "<StrategicRestriction of Game '%s'>" % self.title
 
     def __richcmp__(StrategicRestriction self, other, whichop):
         if isinstance(other, StrategicRestriction):
@@ -206,30 +206,16 @@ cdef class StrategicRestriction(BaseGame):
         def __get__(self):
             return self.unrestrict().is_perfect_recall
 
-    def delete(self, strat):
-        cdef StrategicRestriction new_support
-        if isinstance(strat, Strategy):
-            new_support = StrategicRestriction()
-            new_support.support = self.support
-            new_support.support.RemoveStrategy((<Strategy>strat).strategy)
-            return new_support
-        raise TypeError("delete requires a Strategy object")
-
-    def undominated(self, strict=False, external=False):
+    def undominated(self, strict=False):
         cdef StrategicRestriction new_support
         new_support = StrategicRestriction()
-        new_support.support = self.support.Undominated(strict, external)
+        new_support.support = self.support.Undominated(strict, False)
         return new_support
-
-    def issubset(self, spt):
-        if isinstance(spt, StrategicRestriction):
-            return self.support.IsSubsetOf((<StrategicRestriction>spt).support)
-        raise TypeError("issubset requires a StrategicRestriction object")
 
     def num_strategies_player(self, pl):
         return self.support.NumStrategiesPlayer(pl+1)
 
-    def support_set(self):
+    def support_profile(self):
         return StrategySupportProfile(list(self.strategies), len(self.players), self.unrestrict())
 
     def restrict(self, StrategySupportProfile sp):

--- a/src/python/gambit/lib/stratspt.pxi
+++ b/src/python/gambit/lib/stratspt.pxi
@@ -88,7 +88,12 @@ cdef class StrategySupportProfile(Collection):
         return other.issubset(self)
 
     def restrict(self):
-        return self.game.restrict(self)
+        cdef StrategicRestriction new_support
+        new_support = self.game.mixed_profile().support()
+        for strategy in self.game.strategies:
+            if strategy not in self:
+                new_support.support.RemoveStrategy((<Strategy>strategy).strategy)
+        return new_support
 
     def undominated(self, strict=False, external=False):
         return self.restrict().undominated(strict, external)
@@ -217,19 +222,6 @@ cdef class StrategicRestriction(BaseGame):
 
     def support_profile(self):
         return StrategySupportProfile(list(self.strategies), len(self.players), self.unrestrict())
-
-    def restrict(self, StrategySupportProfile sp):
-        cdef StrategicRestriction new_support
-        support = self.support_set()
-        if support >= sp:
-            difference = set(support) - set(sp)
-            new_support = StrategicRestriction()
-            new_support.support = self.support
-            for strategy in difference:
-                new_support.support.RemoveStrategy((<Strategy>strategy).strategy)
-            return new_support
-        else:
-            raise UndefinedOperationError("cannot restrict game to a non-subset of it")
 
     def unrestrict(self):
         cdef Game g


### PR DESCRIPTION
This outlines concepts and terminology for manipulating support profiles and restrictions of a game.

Loosely, a "support profile" is a subset of a game's strategies.  A "restriction" is a game that is derived from another game by dropping strategies.  Support profiles can be modified freely.  Restrictions however are intended to be read-only/immutable.

In this implementation the one particularly awkward bit is StrategySupportProfile.undominated().  I think with these new concepts, we can move to using a c_StrategySupport internally for StrategySupportProfile, which could simplify this, and other parts of the StrategySupportProfile implementation.

I have left the development of this idea as a series of small commits, but they could easily be collapsed into one commit for merge.
